### PR TITLE
Add type check to shortcode $atts (minimal fix for #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * __Requires at least:__ [WordPress 2.5](http://wordpress.org/download) or later
 * __Tested up to:__ WordPress 4.9.2
-* __Stable version:__ [2.3](https://downloads.wordpress.org/plugin/bookmarks-shortcode.latest-stable.zip)
+* __Stable version:__ [2.3.1](https://downloads.wordpress.org/plugin/bookmarks-shortcode.latest-stable.zip)
 * __License:__ [MIT](https://opensource.org/licenses/mit)
 
 Creates shortcodes that will generate an unordered list of your WordPress links (bookmarks).
@@ -38,6 +38,9 @@ If you wish to use these shortcodes in the sidebar text widgets, add this code t
 Keep in mind that doing this will allow you to use **all** shortcodes in text widgets, not only the ones added by this plugin
 
 ## Changelog
+
+### 2.3.1
+* Fixed regression if strings are passed as shortcode attributes
 
 ### 2.3
 * Remove argument parsing from shortcode callback

--- a/bookmarks-shortcode.php
+++ b/bookmarks-shortcode.php
@@ -34,7 +34,13 @@
  * @return string The formatted list of bookmarks
  */
 function bookmarks_shortcode( $atts = array() ) {
-	$atts['echo'] = false;
+	if ( empty( $atts ) ) {
+		$atts = array( 'echo' => false );
+	} elseif ( is_array( $atts ) ) {
+		$atts['echo'] = false;
+	} elseif ( is_string( $atts ) ) {
+		$atts = 'echo=false&' . $atts;
+	}
 	return wp_list_bookmarks( $atts );
 }
 

--- a/bookmarks-shortcode.php
+++ b/bookmarks-shortcode.php
@@ -8,13 +8,13 @@
  * Author URI:  http://bungeshea.com
  * License:     MIT
  * License URI: http://opensource.org/licenses/MIT
- * Version:     2.3
+ * Version:     2.3.1
  */
 
 /**
  * Creates shortcodes that will generate an unordered list of your WordPress links (bookmarks).
  *
- * @version   2.3
+ * @version   2.3.1
  * @author    Shea Bunge <info@bungeshea.com>
  * @copyright Copyright (c) 2011 - 2018, Shea Bunge
  * @link      https://github.com/sheabunge/bookmarks-shortcode

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bungeshea
 Tags: bookmarks, links, blogroll, shortcode, wp_list_bookmarks
 Requires at least: 2.5
 Tested up to: 4.9.2
-Stable tag: 2.3
+Stable tag: 2.3.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 Donate link: https://bungeshea.com/donate/
@@ -43,6 +43,9 @@ If you wish to use these shortcodes in the sidebar text widgets, add this code t
 Keep in mind that doing this will allow you to use **all** shortcodes in text widgets, not only the ones added by this plugin
 
 == Changelog ==
+
+= 2.3.1 =
+* Fixed regression if strings are passed as shortcode attributes
 
 = 2.3 =
 * Remove argument parsing from shortcode callback


### PR DESCRIPTION
Fixes regression from 89f88e2 in v2.3 which breaks `echo=false` behavior if strings are passed to the shortcode. 

This adds a minimal check for three possible arguments without reverting to `wp_parse_args()`